### PR TITLE
Release 0.10.2

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -68,7 +68,7 @@ jobs:
         with:
           context: .
           file: ./dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}:${{ steps.extractVersion.outputs.version }},${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}:latest
           labels: ${{ steps.meta.outputs.labels }}

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.icaroerasmo</groupId>
   <artifactId>java-rtsp-recorder</artifactId>
-  <version>0.10.1</version>
+  <version>0.10.2</version>
   <name>Java RTSP Recorder</name>
   <properties>
     <maven.compiler.source>21</maven.compiler.source>


### PR DESCRIPTION
## Summary
- limit published recorder image to linux/amd64
- keep the Arch-based GPU runtime releaseable on GitHub Actions